### PR TITLE
add tf files that were not included in WinRM update

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -50,45 +50,45 @@ module "windows_workers" {
   security_group_id     = module.common.security_group_id
   image_id              = module.common.windows_2019_image_id
   kube_cluster_tag      = module.common.kube_cluster_tag
-  ssh_key               = var.cluster_name
   instance_profile_name = module.common.instance_profile_name
   worker_type           = var.worker_type
+  windows_administrator_password = var.windows_administrator_password
 }
 
 locals {
   managers = [
     for host in module.masters.machines : {
       address = host.public_ip
-      role    = host.tags["Role"]
-      privateInterface = "ens5"
       ssh = {
         user    = "ubuntu"
         keyPath = "./ssh_keys/${var.cluster_name}.pem"
       }
+      role    = host.tags["Role"]
+      privateInterface = "ens5"
     }
   ]
   workers = [
     for host in module.workers.machines : {
       address = host.public_ip
-      role    = host.tags["Role"]
-      privateInterface = "ens5"
       ssh = {
         user    = "ubuntu"
         keyPath = "./ssh_keys/${var.cluster_name}.pem"
       }
+      role    = host.tags["Role"]
+      privateInterface = "ens5"
     }
   ]
   windows_workers = [
     for host in module.windows_workers.machines : {
       address = host.public_ip
-      role    = host.tags["Role"]
-      privateInterface = "Ethernet 2"
       winRM = {
         user    = "Administrator"
         password = var.windows_administrator_password
         useHTTPS = true
         insecure = true
       }
+      role    = host.tags["Role"]
+      privateInterface = "Ethernet 2"
     }
   ]
 }

--- a/examples/terraform/aws/modules/windows_worker/main.tf
+++ b/examples/terraform/aws/modules/windows_worker/main.tf
@@ -15,7 +15,6 @@ locals {
   subnet_count = length(var.subnet_ids)
 }
 
-
 resource "aws_instance" "ucp_worker" {
   count = var.worker_count
 
@@ -83,6 +82,7 @@ Set-Service WinRM -StartupType "Automatic"
 Start-Service WinRM
 </powershell>
 EOF
+
 
   lifecycle {
     ignore_changes = [ami]

--- a/examples/terraform/aws/modules/windows_worker/variables.tf
+++ b/examples/terraform/aws/modules/windows_worker/variables.tf
@@ -14,10 +14,6 @@ variable "image_id" {}
 
 variable "kube_cluster_tag" {}
 
-variable "ssh_key" {
-  description = "SSH key name"
-}
-
 variable "worker_count" {
   default = 0
 }

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -42,3 +42,6 @@ variable "master_volume_size" {
 variable "worker_volume_size" {
   default = 100
 }
+
+variable "windows_administrator_password" {
+}


### PR DESCRIPTION
add tf files from mcc that were not included in WinRM update

Signed-off-by: Jim Ehrismann <jehrismann@mirantis.com>

fixes:
```
$ terraform apply

Warning: Value for undeclared variable

The root module does not declare a variable named
"windows_administrator_password" but a value was found in file
"terraform.tfvars". To use this value, add a "variable" block to the
configuration.

Using a variables file to set an undeclared variable is deprecated and will
become an error in a future release. If you wish to provide certain "global"
settings to all configurations in your organization, use TF_VAR_...
environment variables to set these instead.


Error: Missing required argument

  on main.tf line 44, in module "windows_workers":
  44: module "windows_workers" {

The argument "windows_administrator_password" is required, but no definition
was found.
```
