### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,10 +66,12 @@ spec:
     role: manager
     ssh:
       keyPath: ~/.ssh/my_key
+      user: ubuntu
   - address: 192.168.110.101
     role: worker
     ssh:
       keyPath: ~/.ssh/my_key
+      user: ubuntu
 ```
 
 For more complex setups, there's a huge amount of [configuration options](configuration-file.md) available.


### PR DESCRIPTION
Since the ssh user is frequently non-root (most AWS-provided AMIs in AWS use a non-root user for the generated ssh key by default), we should specify the "user" value.
Leaving this out causes Launchpad to assume the user is root, which results in the following error if the ssh key is for a non-root user:
```
FATA[0065] failed on 3 hosts:
 - [IPAddr]: [IPAddr]: has unsupported OS (Please login as the user "ubuntu" rather than the user "root".)
```