### PR TITLE
Roll back yaml filename for now

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -12,7 +12,7 @@ Optional arguments that can be used with any of the `launchpad` commands.
 
 ## Initialize Launchpad
 
-Intializes the cluster config file, usually called launchpad.yaml.
+Intializes the cluster config file, usually called cluster.yaml.
 
 `launchpad init`
 
@@ -26,7 +26,7 @@ initialize or upgrade a cluster.
 The supported options are:
 
 * `--config` - Path to a cluster config file, including the filename
-(default: `launchpad.yaml`)
+(default: `cluster.yaml`)
 * `--prune` - Remove nodes that are no longer in the cluster config yaml
 (default: `false`)
 * `--force` - Continue installation when prerequisite validation fails
@@ -35,7 +35,7 @@ The supported options are:
 ## Download a client bundle
 
 The client bundle contains a private and public key pair that authorizes
-Launchpad to interact with 
+Launchpad to interact with
 [UCP CLI](https://docs.mirantis.com/docker-enterprise/v3.1/dockeree-products/ucp/user-access.html#cli-access).
 
 `launchpad download-bundle`
@@ -45,7 +45,7 @@ The supported options are:
 * `--username` - Username
 * `--password` - Password
 * `--config` - Path to a cluster config file, including the filename
-(default: `launchpad.yaml`)
+(default: `cluster.yaml`)
 
 ## Register
 
@@ -67,7 +67,7 @@ To reset or uninstall a UCP cluster.
 
 The supported options are:
 
-* `--config` - Path to a cluster config file, including the filename (default: `launchpad.yaml`)
+* `--config` - Path to a cluster config file, including the filename (default: `cluster.yaml`)
 
 ## Related topics
 

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -1,10 +1,10 @@
 # Mirantis Launchpad Configuration File
 
-Mirantis Launchpad cluster configuration is described in YAML format. You can create and modify yaml files using your favorite text editor. The default name for this file is launchpad.yaml, although other file names could be used.
+Mirantis Launchpad cluster configuration is described in YAML format. You can create and modify yaml files using your favorite text editor. The default name for this file is cluster.yaml, although other file names could be used.
 
 ## Configuration File Reference
 
-The complete `launchpad.yaml` file looks something like this, but with values determined by your specific configuration.
+The complete `cluster.yaml` file looks something like this, but with values determined by your specific configuration.
 
 ```yaml
 apiVersion: launchpad.mirantis.com/v1beta3
@@ -127,7 +127,7 @@ SSH configuration options.
 
 #### `winRM`
 
-WinRM configuration options. 
+WinRM configuration options.
 
 - `user` - Windows account username (default: `Administrator`)
 - `password` - User account password

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,7 +77,7 @@ INFO[0022] Registration completed!
 
 The cluster is configured using [a yaml file](configuration-file.md). In this example we setup a simple 2 node UCP cluster using Kubernetes. One node is used for UCP and one is a worker node.
 
-Open up your favorite editor, and type something similar to the example below. Once done, save the file as `launchpad.yaml`. Adjust the example below to meet your infrastructure requirements. This model should work to deploy hosts on most public clouds.
+Open up your favorite editor, and type something similar to the example below. Once done, save the file as `cluster.yaml`. Adjust the example below to meet your infrastructure requirements. This model should work to deploy hosts on most public clouds.
 
 ```yaml
 apiVersion: launchpad.mirantis.com/v1beta3
@@ -101,7 +101,7 @@ spec:
       keyPath: ~/.ssh/my_key
 ```
 
-If you're deploying on VirtualBox or other desktop virtualization solution and are using ‘bridged’ networking, you’ll need to make a few minor adjustments to your launchpad.yaml (see below) — deliberately setting a –pod-cidr to ensure that pod IP addresses don’t overlap with node IP addresses (the latter are in the 192.168.x.x private IP network range on such a setup), and supplying appropriate labels for the target nodes’ private IP network cards using the privateInterface parameter (this typically defaults to ‘enp0s3’ on Ubuntu 18.04 &mdash; other Linux distributions use similar nomenclature). You may also need to set the username to use for logging into the host.
+If you're deploying on VirtualBox or other desktop virtualization solution and are using ‘bridged’ networking, you’ll need to make a few minor adjustments to your cluster.yaml (see below) — deliberately setting a –pod-cidr to ensure that pod IP addresses don’t overlap with node IP addresses (the latter are in the 192.168.x.x private IP network range on such a setup), and supplying appropriate labels for the target nodes’ private IP network cards using the privateInterface parameter (this typically defaults to ‘enp0s3’ on Ubuntu 18.04 &mdash; other Linux distributions use similar nomenclature). You may also need to set the username to use for logging into the host.
 
 ```yaml
 apiVersion: launchpad.mirantis.com/v1beta3
@@ -135,13 +135,13 @@ If you are familiar with [Terraform](https://www.terraform.io/), you can automat
 
 ## Bootstrap your cluster
 
-Once the cluster configuration file is ready, we can fire up the cluster. In the same directory where you created the `launchpad.yaml` file, run:
+Once the cluster configuration file is ready, we can fire up the cluster. In the same directory where you created the `cluster.yaml` file, run:
 
 ```
 $ launchpad apply
 ```
 
-The `launchpad` tool uses with SSH or WinRM to connect to the infrastructure you've specified in the `launchpad.yaml` and configures everything needed on the hosts. Within few minutes you should have your cluster up and running.
+The `launchpad` tool uses with SSH or WinRM to connect to the infrastructure you've specified in the `cluster.yaml` and configures everything needed on the hosts. Within few minutes you should have your cluster up and running.
 
 ## Connect to your cluster
 
@@ -153,7 +153,7 @@ INFO[0021] UCP cluster admin UI: https://test-ucp-cluster-master-lb-895b79a08e57
 INFO[0021] You can also download the admin client bundle with the following command: launchpad download-bundle --username <username> --password <password>
 ```
 
-By default, the admin username is `admin`. If you did not supply the password in with `launchpad.yaml` or via the `installFlags` option like `--admin-password=supersecret`, the generated admin password will be displayed in the install flow:
+By default, the admin username is `admin`. If you did not supply the password in with `cluster.yaml` or via the `installFlags` option like `--admin-password=supersecret`, the generated admin password will be displayed in the install flow:
 ```
 INFO[0083] 127.0.0.1:  time="2020-05-26T05:25:12Z" level=info msg="Generated random admin password: wJm-TzIzQrRNx7d1fWMdcscu_1pN5Xs0"
 ```

--- a/docs/host-configuration.md
+++ b/docs/host-configuration.md
@@ -27,7 +27,7 @@ Hosts must be configured to allow:
 
 * _Configure Docker logging to enable auto-rotation and manage retention_ * &mdash; Additionally, we recommend configuring evaluation hosts, especially those with smaller SSDs/HDDs, to enable basic Docker log rotation and managing old-file retention, thus avoiding filling up cluster storage with retained logs.
 
-This can be done by defining Docker engine configuration in launchpad.yaml, for example:
+This can be done by defining Docker engine configuration in cluster.yaml, for example:
 
 ```yaml
 ...

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,10 +1,10 @@
 # Integrating with Mirantis Launchpad
 
-Mirantis Launchpad is distributed as a binary executable. The main integration point with cluster management is the `launchpad apply` command and the input [`launchpad.yaml`](configuration-file.md) configuration for the cluster. As the configuration is in YAML format you can integrate other tooling with it. One of the common use cases uses infrastructure management tooling such as Terraform.
+Mirantis Launchpad is distributed as a binary executable. The main integration point with cluster management is the `launchpad apply` command and the input [`cluster.yaml`](configuration-file.md) configuration for the cluster. As the configuration is in YAML format you can integrate other tooling with it. One of the common use cases uses infrastructure management tooling such as Terraform.
 
 ## Terraform with Mirantis Launchpad
 
-When using cloud environments many people use [Terraform](https://www.terraform.io/) to manage the infrastructure declaratively. The easiest way to integrate Terraform to Mirantis Launchpad is to use [Terraform output](https://www.terraform.io/docs/configuration/outputs.html) values to specify the whole [`launchpad.yaml`](configuration-file.md) structure. 
+When using cloud environments many people use [Terraform](https://www.terraform.io/) to manage the infrastructure declaratively. The easiest way to integrate Terraform to Mirantis Launchpad is to use [Terraform output](https://www.terraform.io/docs/configuration/outputs.html) values to specify the whole [`cluster.yaml`](configuration-file.md) structure.
 
 ```terraform
 output "ucp_cluster" {
@@ -26,10 +26,10 @@ output "ucp_cluster" {
 }
 ```
 
-Terraform is currently limited to output json format. To convert the json to yaml, you can use a tool called [`yq`](https://github.com/mikefarah/yq) that converts the json to yaml so you can use command piping to convert the Terraform output to `launchpad.yaml`.
+Terraform is currently limited to output json format. To convert the json to yaml, you can use a tool called [`yq`](https://github.com/mikefarah/yq) that converts the json to yaml so you can use command piping to convert the Terraform output to `cluster.yaml`.
 
 ```
-terraform output -json | yq r --prettyPrint - ucp_cluster.value > launchpad.yaml
+terraform output -json | yq r --prettyPrint - ucp_cluster.value > cluster.yaml
 ```
 
 You can now use the `launchpad apply` command, and Launchpad will install all the needed cluster components.

--- a/docs/node-management.md
+++ b/docs/node-management.md
@@ -16,25 +16,25 @@ Swarm manager nodes use the Raft Consensus Algorithm to manage the swarm state. 
 
 ## Adding Manager Nodes
 
-Adding manager nodes is as simple as adding them to `launchpad.yaml`. Re-running `launchpad apply` will configure UCP on the new node and also makes necessary changes in the swarm & etcd cluster.
+Adding manager nodes is as simple as adding them to `cluster.yaml`. Re-running `launchpad apply` will configure UCP on the new node and also makes necessary changes in the swarm & etcd cluster.
 
 ## Removing Manager Nodes
 
 Follow this process after you determine that it is safe to remove a manager node and its `etcd` peer.
 
-1. Remove the manager host from `launchpad.yaml`
+1. Remove the manager host from `cluster.yaml`
 2. Run `launchpad apply --prune ...`
 3. Terminate/remove the node in your infrastructure
 
 ## Adding Worker Nodes
 
-Adding worker nodes is as simple as adding them into the `launchpad.yaml`. Re-running `launchpad apply` will configure everything on the new node and joins it into the cluster.
+Adding worker nodes is as simple as adding them into the `cluster.yaml`. Re-running `launchpad apply` will configure everything on the new node and joins it into the cluster.
 
 ## Removing Worker Nodes
 
 Removing a worker node is a multi-step process:
 
-1. Remove the host from `launchpad.yaml`.
+1. Remove the host from `cluster.yaml`.
 2. Run `launchpad apply --prune ...`
 3. Terminate/remove the node in your infrastructure
 
@@ -48,7 +48,7 @@ The quorum formed by DTR utilizes RethinkDB which, just like swarm, uses the Raf
 
 ## Adding DTR Nodes
 
-Adding DTR nodes is as simple as adding them into the `launchpad.yaml` file with a host role of `dtr`. When you add a DTR node, specify both the `--admin-username` and `--admin-password` install flags via the `installFlags` section in UCP so that DTR knows what admin credentials to use:
+Adding DTR nodes is as simple as adding them into the `cluster.yaml` file with a host role of `dtr`. When you add a DTR node, specify both the `--admin-username` and `--admin-password` install flags via the `installFlags` section in UCP so that DTR knows what admin credentials to use:
 
 ```
 spec:
@@ -64,6 +64,6 @@ Next, re-run `launchpad apply` which will configure everything on the new node a
 
 Removing a DTR node is currently a multi step process:
 
-1. Remove the host from `launchpad.yaml`.
+1. Remove the host from `cluster.yaml`.
 2. Run `launchpad apply --prune`
 3. Terminate/remove the node in your infrastructure

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -4,7 +4,7 @@ Mirantis Launchpad allows users to upgrade their clusters with the `launchpad ap
 
 ## Upgrading Docker Engine - Enterprise
 
-To upgrade Docker Engine - Enterprise, change the engine version in the `launchpad.yaml` file.
+To upgrade Docker Engine - Enterprise, change the engine version in the `cluster.yaml` file.
 
 ```yaml
 apiVersion: launchpad.mirantis.com/v1beta3
@@ -18,7 +18,7 @@ spec:
   engine:
     version: 19.03.12 # was previously 19.03.8
 ```
-After you update `launchpad.yaml`, you can run `launchpad apply`. Launchpad will upgrade the engine on all hosts in a specific sequence.
+After you update `cluster.yaml`, you can run `launchpad apply`. Launchpad will upgrade the engine on all hosts in a specific sequence.
 
 1. Upgrade the engine on each manager node one-by-one. This means that if you have more than one manager node, the other manager nodes are available while the first node is updated.
 
@@ -28,7 +28,7 @@ After you update `launchpad.yaml`, you can run `launchpad apply`. Launchpad will
 
 ## Upgrading UCP or DTR
 
-When a newer version of UCP or DTR is available you can upgrade to it by changing the version tags in the `launchpad.yaml`:
+When a newer version of UCP or DTR is available you can upgrade to it by changing the version tags in the `cluster.yaml`:
 
 ```yaml
 apiVersion: launchpad.mirantis.com/v1beta3
@@ -45,7 +45,7 @@ spec:
     version: 2.8.1
 ```
 
-1. Update the version tags and save `launchpad.yaml`.
+1. Update the version tags and save `cluster.yaml`.
 
 2. Run the `launchpad apply` command.
 
@@ -59,7 +59,7 @@ spec:
 
 You can upgrade all of the components -- engine, UCP, and DTR -- at the same time.
 
-1. Update `launchpad.yaml`, as shown in the previous sections.
+1. Update `cluster.yaml`, as shown in the previous sections.
 
 2. Run the `launchpad apply` command.
 

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -13,5 +13,5 @@ This directory provides an example flow for using Mirantis Launchpad with Terraf
 1. Create terraform.tfvars file with needed details. You can use the provided terraform.tfvars.example as a baseline.
 2. `terraform init`
 3. `terraform apply`
-4. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > launchpad.yaml`
+4. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > cluster.yaml`
 5. `launchpad apply`

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -14,5 +14,5 @@ This directory provides an example flow with Mirantis Launchpad tool together wi
 1. Create terraform.tfvars file with needed details. You can use the provided terraform.tfvars.example as a baseline.
 2. `terraform init`
 3. `terraform apply`
-4. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > launchpad.yaml `
+4. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > cluster.yaml `
 5. `launchpad apply`

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -14,10 +14,10 @@ This directory provides an example flow with Mirantis Launchpad together with Te
 1. Create terraform.tfvars file with needed details. You can use the provided terraform.tfvars.example as a baseline.
 2. `terraform init`
 3. Create SSH key and configure path
-4. Create Cloud Provider config file and configure path 
+4. Create Cloud Provider config file and configure path
 5. Configure .tfvars file with all necessary parameters
 6. `terraform apply`
-7. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > launchpad.yaml`
+7. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > cluster.yaml`
 8. `launchpad apply`
 
 ## Related topics

--- a/examples/terraform/vmware/README.md
+++ b/examples/terraform/vmware/README.md
@@ -14,5 +14,5 @@ This directory provides an example flow with Mirantis Launchpad tool together wi
 1. Create a terraform.tfvars file with the necessary details. You can use the provided terraform.tfvars.example as a baseline.
 2. `terraform init`
 3. `terraform apply`
-4. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > launchpad.yaml `
+4. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > cluster.yaml `
 5. `launchpad apply`


### PR DESCRIPTION
The DOC PR #44 was merged accidentally and it had the default config filename changed.

This rolls it back to cluster.yaml.
