### PR TITLE
Change examples to use yamlencode

### DIFF
--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -13,5 +13,5 @@ This directory provides an example flow for using Mirantis Launchpad with Terraf
 1. Create terraform.tfvars file with needed details. You can use the provided terraform.tfvars.example as a baseline.
 2. `terraform init`
 3. `terraform apply`
-4. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > launchpad.yaml`
+4. `terraform output ucp_cluster > launchpad.yaml`
 5. `launchpad apply`

--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -42,16 +42,16 @@ module "workers" {
 }
 
 module "windows_workers" {
-  source                = "./modules/windows_worker"
-  worker_count          = var.windows_worker_count
-  vpc_id                = module.vpc.id
-  cluster_name          = var.cluster_name
-  subnet_ids            = module.vpc.public_subnet_ids
-  security_group_id     = module.common.security_group_id
-  image_id              = module.common.windows_2019_image_id
-  kube_cluster_tag      = module.common.kube_cluster_tag
-  instance_profile_name = module.common.instance_profile_name
-  worker_type           = var.worker_type
+  source                         = "./modules/windows_worker"
+  worker_count                   = var.windows_worker_count
+  vpc_id                         = module.vpc.id
+  cluster_name                   = var.cluster_name
+  subnet_ids                     = module.vpc.public_subnet_ids
+  security_group_id              = module.common.security_group_id
+  image_id                       = module.common.windows_2019_image_id
+  kube_cluster_tag               = module.common.kube_cluster_tag
+  instance_profile_name          = module.common.instance_profile_name
+  worker_type                    = var.worker_type
   windows_administrator_password = var.windows_administrator_password
 }
 
@@ -63,7 +63,7 @@ locals {
         user    = "ubuntu"
         keyPath = "./ssh_keys/${var.cluster_name}.pem"
       }
-      role    = host.tags["Role"]
+      role             = host.tags["Role"]
       privateInterface = "ens5"
     }
   ]
@@ -74,7 +74,7 @@ locals {
         user    = "ubuntu"
         keyPath = "./ssh_keys/${var.cluster_name}.pem"
       }
-      role    = host.tags["Role"]
+      role             = host.tags["Role"]
       privateInterface = "ens5"
     }
   ]
@@ -82,25 +82,21 @@ locals {
     for host in module.windows_workers.machines : {
       address = host.public_ip
       winRM = {
-        user    = "Administrator"
+        user     = "Administrator"
         password = var.windows_administrator_password
         useHTTPS = true
         insecure = true
       }
-      role    = host.tags["Role"]
+      role             = host.tags["Role"]
       privateInterface = "Ethernet 2"
     }
   ]
-}
-
-
-output "ucp_cluster" {
-  value = {
+  launchpad_tmpl = {
     apiVersion = "launchpad.mirantis.com/v1"
-    kind = "DockerEnterprise"
+    kind       = "DockerEnterprise"
     spec = {
       ucp = {
-        installFlags: [
+        installFlags : [
           "--admin-username=admin",
           "--admin-password=${var.admin_password}",
           "--default-node-orchestrator=kubernetes",
@@ -110,4 +106,9 @@ output "ucp_cluster" {
       hosts = concat(local.managers, local.workers, local.windows_workers)
     }
   }
+}
+
+
+output "ucp_cluster" {
+  value = yamlencode(local.launchpad_tmpl)
 }

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -14,5 +14,5 @@ This directory provides an example flow with Mirantis Launchpad tool together wi
 1. Create terraform.tfvars file with needed details. You can use the provided terraform.tfvars.example as a baseline.
 2. `terraform init`
 3. `terraform apply`
-4. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > launchpad.yaml `
+4. `terraform output ucp_cluster > launchpad.yaml `
 5. `launchpad apply`

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -17,7 +17,7 @@ This directory provides an example flow with Mirantis Launchpad together with Te
 4. Create Cloud Provider config file and configure path 
 5. Configure .tfvars file with all necessary parameters
 6. `terraform apply`
-7. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > launchpad.yaml`
+7. `terraform output ucp_cluster > launchpad.yaml`
 8. `launchpad apply`
 
 ## Related topics

--- a/examples/terraform/openstack/output.tf
+++ b/examples/terraform/openstack/output.tf
@@ -43,10 +43,7 @@ locals {
       }
     }
   ]
-}
-
-output "ucp_cluster" {
-  value = {
+  launchpad_tmpl = {
     apiVersion = "launchpad.mirantis.com/v1"
     kind = "DockerEnterprise"
     metadata = {
@@ -75,4 +72,8 @@ output "ucp_cluster" {
       hosts = concat(local.managers, local.workers)
     }
   }
+}
+
+output "ucp_cluster" {
+  value = yamlencode(local.launchpad_tmpl)
 }

--- a/examples/terraform/vmware/README.md
+++ b/examples/terraform/vmware/README.md
@@ -14,5 +14,5 @@ This directory provides an example flow with Mirantis Launchpad tool together wi
 1. Create a terraform.tfvars file with the necessary details. You can use the provided terraform.tfvars.example as a baseline.
 2. `terraform init`
 3. `terraform apply`
-4. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > launchpad.yaml `
+4. `terraform output ucp_cluster > launchpad.yaml `
 5. `launchpad apply`

--- a/examples/terraform/vmware/main.tf
+++ b/examples/terraform/vmware/main.tf
@@ -38,27 +38,27 @@ data "vsphere_virtual_machine" "template_vm_linux" {
 # }
 
 module "managers" {
-  source = "./modules/virtual_machine"
-  quantity = var.quantity_managers
-  name_prefix = "manager"
-  resource_pool_id = data.vsphere_resource_pool.resource_pool.id
+  source               = "./modules/virtual_machine"
+  quantity             = var.quantity_managers
+  name_prefix          = "manager"
+  resource_pool_id     = data.vsphere_resource_pool.resource_pool.id
   datastore_cluster_id = data.vsphere_datastore_cluster.datastore_cluster.id
-  folder = var.folder
-  network_id = data.vsphere_network.network.id
-  template_vm = data.vsphere_virtual_machine.template_vm_linux
-  disk_size = 16
+  folder               = var.folder
+  network_id           = data.vsphere_network.network.id
+  template_vm          = data.vsphere_virtual_machine.template_vm_linux
+  disk_size            = 16
 }
 
 module "workers" {
-  source = "./modules/virtual_machine"
-  quantity = var.quantity_workers
-  name_prefix = "worker"
-  resource_pool_id = data.vsphere_resource_pool.resource_pool.id
+  source               = "./modules/virtual_machine"
+  quantity             = var.quantity_workers
+  name_prefix          = "worker"
+  resource_pool_id     = data.vsphere_resource_pool.resource_pool.id
   datastore_cluster_id = data.vsphere_datastore_cluster.datastore_cluster.id
-  folder = var.folder
-  network_id = data.vsphere_network.network.id
-  template_vm = data.vsphere_virtual_machine.template_vm_linux
-  disk_size = 16
+  folder               = var.folder
+  network_id           = data.vsphere_network.network.id
+  template_vm          = data.vsphere_virtual_machine.template_vm_linux
+  disk_size            = 16
 }
 
 # module "workers_windows" {

--- a/examples/terraform/vmware/outputs.tf
+++ b/examples/terraform/vmware/outputs.tf
@@ -1,8 +1,8 @@
 locals {
   managers = [
     for host in module.managers.machines : {
-      address = host.default_ip_address
-      role    = "manager"
+      address          = host.default_ip_address
+      role             = "manager"
       privateInterface = "ens5" # Is this supposed to be a constant?
       ssh = {
         user    = "ubuntu" # "TODO: Probably make this a variable"
@@ -12,8 +12,8 @@ locals {
   ]
   workers = [
     for host in module.workers.machines : {
-      address = host.default_ip_address
-      role    = "worker"
+      address          = host.default_ip_address
+      role             = "worker"
       privateInterface = "ens5" # Is this supposed to be a constant?
       ssh = {
         user    = "ubuntu" # "TODO: Probably make this a variable"
@@ -32,15 +32,12 @@ locals {
   #     }
   #   }
   # ]
-}
-
-output "ucp_cluster" {
-  value = {
+  launchpad_tmpl = {
     apiVersion = "launchpad.mirantis.com/v1"
-    kind = "DockerEnterprise"
+    kind       = "DockerEnterprise"
     spec = {
       ucp = {
-        installFlags: [
+        installFlags : [
           "--admin-username=${var.ucp_admin_username}",
           "--admin-password=${var.ucp_admin_password}",
           "--default-node-orchestrator=kubernetes",
@@ -50,4 +47,8 @@ output "ucp_cluster" {
       hosts = concat(local.managers, local.workers) #, local.windows_workers)
     }
   }
+}
+
+output "ucp_cluster" {
+  value = yamlencode(local.launchpad_tmpl)
 }

--- a/examples/terraform/vmware/variables.tf
+++ b/examples/terraform/vmware/variables.tf
@@ -11,24 +11,24 @@ variable "vsphere_password" {
 }
 
 variable "datacenter" {
-    default = ""
+  default = ""
 }
 
 variable "resource_pool" {
 }
 
 variable "folder" {
-    default = ""
+  default = ""
 }
 
-variable "datastore_cluster" {    
+variable "datastore_cluster" {
 }
 
 variable "network" {
 }
 
 variable "template_vm_linux" {
-    description = "VM to use as a template for the linux nodes (managers, workers)"
+  description = "VM to use as a template for the linux nodes (managers, workers)"
 }
 
 # variable "template_vm_windows" {
@@ -41,7 +41,7 @@ variable "ssh_private_key_file" {
 
 variable "ucp_admin_username" {
   description = "Desired username for the UCP admin account"
-  default = "admin"
+  default     = "admin"
 }
 
 variable "ucp_admin_password" {
@@ -54,12 +54,12 @@ variable "ucp_lb_dns_name" {
 
 variable "quantity_managers" {
   description = "Number of UCP manager VMs to create"
-  default = 3
+  default     = 3
 }
 
 variable "quantity_workers" {
   description = "Number of UCP worker VMs to create"
-  default = 3
+  default     = 3
 }
 
 # variable "quantity_workers_windows" {


### PR DESCRIPTION
Terraform has a yamlencode function that can be used to convert the computed config objects into yaml config for launchpad. This removes the need for yq.

Terraform fmt has also been run against the examples, which explains the formatting changes.