### PR TITLE
Adapt Azure TF example to use yamlencode

### DIFF
--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -4,7 +4,7 @@ Working examples for using Terraform with Mirantis Launchpad. The scripts are pr
 
 
 * [AWS](aws/README.md), a complete infrastructure example including VPC, LB, security groups, and other settings.
-* [Azure](azure/README.md), a complete exampe including VNET, LB, network security rules, and other settings.
+* [Azure](azure/README.md), a complete example including VNET, LB, network security rules, and other settings.
 * [Hetzner](hetzner/README.md), a simple example with just a couple of VMs provisioned for a UCP cluster.
 * [OpenStack](openstack/README.md), a simple example with basic settings.
 * [VMware](vmware/README.md), a simple example using existing vSphere network.

--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -3,8 +3,8 @@
 Working examples for using Terraform with Mirantis Launchpad. The scripts are provided as examples; you can change them to fit your specific configuration requirements or create your own.
 
 
-* [AWS](aws/README.md), a complete infrastructure example including VPC, LB, security groups, and other settings. 
-
+* [AWS](aws/README.md), a complete infrastructure example including VPC, LB, security groups, and other settings.
+* [Azure](azure/README.md), a complete exampe including VNET, LB, network security rules, and other settings.
 * [Hetzner](hetzner/README.md), a simple example with just a couple of VMs provisioned for a UCP cluster.
-
+* [OpenStack](openstack/README.md), a simple example with basic settings.
 * [VMware](vmware/README.md), a simple example using existing vSphere network.

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -6,7 +6,6 @@ This directory provides an example flow for using Mirantis Launchpad with Terraf
 
 * An account and credentials for AWS.
 * Terraform [installed](https://learn.hashicorp.com/terraform/getting-started/install)
-* [yq installed](https://github.com/mikefarah/yq#install)
 
 ## Steps
 

--- a/examples/terraform/azure/README.md
+++ b/examples/terraform/azure/README.md
@@ -13,7 +13,7 @@ This directory provides an example flow for using Mirantis Launchpad with Terraf
 1. Create terraform.tfvars file with needed details. You can use the provided terraform.tfvars.example as a baseline.
 2. `terraform init`
 3. `terraform apply`
-4. `terraform output -json | yq r --prettyPrint - ucp_cluster.value > launchpad.yaml`
+4. `terraform output ucp_cluster > launchpad.yaml`
 5. `launchpad apply`
 
 ## Notes

--- a/examples/terraform/azure/README.md
+++ b/examples/terraform/azure/README.md
@@ -6,7 +6,6 @@ This directory provides an example flow for using Mirantis Launchpad with Terraf
 
 * An account and credentials for Azure.
 * Terraform [installed](https://learn.hashicorp.com/terraform/getting-started/install)
-* [yq installed](https://github.com/mikefarah/yq#install)
 
 ## Steps
 

--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -111,8 +111,8 @@ locals {
   ]
 }
 
-output "ucp_cluster" {
-  value = {
+locals {
+  launchpad_tmpl = {
     apiVersion = "launchpad.mirantis.com/v1"
     kind       = "DockerEnterprise"
     metadata = {
@@ -130,6 +130,10 @@ output "ucp_cluster" {
       hosts = concat(local.managers, local.workers, local.windows_workers)
     }
   }
+}
+
+output "ucp_cluster" {
+  value = yamlencode(local.launchpad_tmpl)
 }
 
 output "loadbalancers" {

--- a/examples/terraform/azure/terraform.tfvars.example
+++ b/examples/terraform/azure/terraform.tfvars.example
@@ -1,5 +1,5 @@
-cluster_name = "my-ucp-cluster"
-master_count = 1
-worker_count = 3
+cluster_name         = "my-ucp-cluster"
+master_count         = 1
+worker_count         = 3
 windows_worker_count = 0
-admin_password = "orcaorcaorca"
+admin_password       = "orcaorcaorca"

--- a/examples/terraform/hetzner/README.md
+++ b/examples/terraform/hetzner/README.md
@@ -7,7 +7,6 @@ This directory provides an example flow with Mirantis Launchpad tool together wi
 
 * You need an account and API token for Hetzner
 * Terraform [installed](https://learn.hashicorp.com/terraform/getting-started/install)
-* [yq installed](https://github.com/mikefarah/yq#install)
 
 ## Steps
 

--- a/examples/terraform/openstack/README.md
+++ b/examples/terraform/openstack/README.md
@@ -6,7 +6,6 @@ This directory provides an example flow with Mirantis Launchpad together with Te
 
 * You need an account and credentials for an OpenStack Tenant.
 * Terraform [installed](https://learn.hashicorp.com/terraform/getting-started/install)
-* [yq installed](https://github.com/mikefarah/yq#install)
 * [Generate SSH key](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key)
 
 ## Steps
@@ -14,7 +13,7 @@ This directory provides an example flow with Mirantis Launchpad together with Te
 1. Create terraform.tfvars file with needed details. You can use the provided terraform.tfvars.example as a baseline.
 2. `terraform init`
 3. Create SSH key and configure path
-4. Create Cloud Provider config file and configure path 
+4. Create Cloud Provider config file and configure path
 5. Configure .tfvars file with all necessary parameters
 6. `terraform apply`
 7. `terraform output ucp_cluster > launchpad.yaml`

--- a/examples/terraform/vmware/README.md
+++ b/examples/terraform/vmware/README.md
@@ -7,7 +7,6 @@ This directory provides an example flow with Mirantis Launchpad tool together wi
 
 * You need VMware vSphere credentials for API operations
 * Terraform [installed](https://learn.hashicorp.com/terraform/getting-started/install)
-* [yq installed](https://github.com/mikefarah/yq#install)
 
 ## Steps
 


### PR DESCRIPTION
Makes the azure example from #53 utilize the `yamlencode` from #57 

Also adds a note about rebooting windows hosts until 1.1 is out.

