### PR TITLE
Add service account, access scopes and instance prefix tags to instances

### DIFF
--- a/examples/terraform/gcp/main.tf
+++ b/examples/terraform/gcp/main.tf
@@ -40,15 +40,16 @@ module "common" {
 }
 
 module "managers" {
-  source          = "./modules/manager"
-  manager_count   = var.manager_count
-  gcp_region      = var.gcp_region
-  gcp_zone        = local.zone
-  cluster_name    = var.cluster_name
-  image_name      = module.common.image_name
-  vpc_name        = module.vpc.vpc_name
-  subnetwork_name = module.vpc.subnet_name
-  ssh_key         = module.common.ssh_key
+  source                = "./modules/manager"
+  manager_count         = var.manager_count
+  gcp_region            = var.gcp_region
+  gcp_zone              = local.zone
+  cluster_name          = var.cluster_name
+  image_name            = module.common.image_name
+  vpc_name              = module.vpc.vpc_name
+  subnetwork_name       = module.vpc.subnet_name
+  ssh_key               = module.common.ssh_key
+  service_account_email = module.common.service_account_email
 }
 
 module "msrs" {
@@ -64,30 +65,32 @@ module "msrs" {
 }
 
 module "workers" {
-  source          = "./modules/worker"
-  worker_count    = var.worker_count
-  gcp_region      = var.gcp_region
-  gcp_zone        = local.zone
-  cluster_name    = var.cluster_name
-  vpc_name        = module.vpc.vpc_name
-  subnetwork_name = module.vpc.subnet_name
-  image_name      = module.common.image_name
-  ssh_key         = module.common.ssh_key
-  worker_type     = var.worker_type
+  source                = "./modules/worker"
+  worker_count          = var.worker_count
+  gcp_region            = var.gcp_region
+  gcp_zone              = local.zone
+  cluster_name          = var.cluster_name
+  vpc_name              = module.vpc.vpc_name
+  subnetwork_name       = module.vpc.subnet_name
+  image_name            = module.common.image_name
+  ssh_key               = module.common.ssh_key
+  worker_type           = var.worker_type
+  service_account_email = module.common.service_account_email
 }
 
 module "windows_workers" {
-  source           = "./modules/windows_worker"
-  worker_count     = var.windows_worker_count
-  gcp_zone         = local.zone
-  cluster_name     = var.cluster_name
-  vpc_name         = module.vpc.vpc_name
-  subnetwork_name  = module.vpc.subnet_name
-  image_name       = module.common.windows_2019_image_name
-  ssh_key          = module.common.ssh_key
-  worker_type      = var.worker_type
-  windows_user     = var.windows_user
-  windows_password = var.windows_password
+  source                = "./modules/windows_worker"
+  worker_count          = var.windows_worker_count
+  gcp_zone              = local.zone
+  cluster_name          = var.cluster_name
+  vpc_name              = module.vpc.vpc_name
+  subnetwork_name       = module.vpc.subnet_name
+  image_name            = module.common.windows_2019_image_name
+  ssh_key               = module.common.ssh_key
+  worker_type           = var.worker_type
+  windows_user          = var.windows_user
+  windows_password      = var.windows_password
+  service_account_email = module.common.service_account_email
 }
 
 locals {

--- a/examples/terraform/gcp/modules/common/main.tf
+++ b/examples/terraform/gcp/modules/common/main.tf
@@ -30,7 +30,7 @@ resource "google_service_account" "default" {
 resource "google_project_iam_member" "default" {
   project = var.project_id
   member  = "serviceAccount:${google_service_account.default.email}"
-  role    = "roles/owner"
+  role    = "roles/compute.admin"
 }
 
 resource "google_compute_firewall" "common_internal" {

--- a/examples/terraform/gcp/modules/common/main.tf
+++ b/examples/terraform/gcp/modules/common/main.tf
@@ -11,14 +11,26 @@ resource "local_file" "ssh_public_key" {
   }
 }
 
+
 data "google_compute_image" "ubuntu" {
-  family  = "ubuntu-1804-lts"
+  family  = "ubuntu-2004-lts"
   project = "ubuntu-os-cloud"
 }
 
 data "google_compute_image" "windows_2019" {
-  family  = "windows-2019-core-for-containers"
+  family  = "windows-2019-core"
   project = "windows-cloud"
+}
+
+resource "google_service_account" "default" {
+  account_id   = "${var.cluster_name}-service-account-id"
+  display_name = "Service Account"
+}
+
+resource "google_project_iam_member" "default" {
+  project = var.project_id
+  member  = "serviceAccount:${google_service_account.default.email}"
+  role    = "roles/owner"
 }
 
 resource "google_compute_firewall" "common_internal" {

--- a/examples/terraform/gcp/modules/common/outputs.tf
+++ b/examples/terraform/gcp/modules/common/outputs.tf
@@ -9,3 +9,7 @@ output "windows_2019_image_name" {
 output "ssh_key" {
   value = tls_private_key.ssh_key
 }
+
+output "service_account_email" {
+  value = google_service_account.default.email
+}

--- a/examples/terraform/gcp/modules/manager/main.tf
+++ b/examples/terraform/gcp/modules/manager/main.tf
@@ -53,11 +53,20 @@ resource "google_compute_instance" "mke_manager" {
     access_config {
     }
   }
+
   tags = [
+    var.cluster_name,
     "allow-ssh",
     "allow-manager",
     "allow-internal"
   ]
+
+  service_account {
+    email = var.service_account_email
+    scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
 }
 
 resource "google_compute_instance_group" "default" {

--- a/examples/terraform/gcp/modules/manager/variables.tf
+++ b/examples/terraform/gcp/modules/manager/variables.tf
@@ -12,6 +12,8 @@ variable "image_name" {}
 
 variable "ssh_key" {}
 
+variable "service_account_email" {}
+
 variable "manager_count" {
   default = 3
 }

--- a/examples/terraform/gcp/modules/msr/main.tf
+++ b/examples/terraform/gcp/modules/msr/main.tf
@@ -37,6 +37,7 @@ resource "google_compute_instance" "mke_msr" {
     }
   }
   tags = [
+    var.cluster_name,
     "allow-ssh",
     "allow-msr",
     "allow-internal"

--- a/examples/terraform/gcp/modules/windows_worker/main.tf
+++ b/examples/terraform/gcp/modules/windows_worker/main.tf
@@ -104,11 +104,19 @@ EOF
   }
 
   tags = [
+    var.cluster_name,
     "allow-rdp",
     "allow-winrm",
     "allow-worker",
     "allow-internal"
   ]
+
+  service_account {
+    email = var.service_account_email
+    scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
 
   provisioner "remote-exec" {
     connection {

--- a/examples/terraform/gcp/modules/windows_worker/variables.tf
+++ b/examples/terraform/gcp/modules/windows_worker/variables.tf
@@ -10,6 +10,8 @@ variable "image_name" {}
 
 variable "ssh_key" {}
 
+variable "service_account_email" {}
+
 variable "worker_count" {
   default = 0
 }

--- a/examples/terraform/gcp/modules/worker/main.tf
+++ b/examples/terraform/gcp/modules/worker/main.tf
@@ -24,9 +24,18 @@ resource "google_compute_instance" "mke_worker" {
     access_config {
     }
   }
+
   tags = [
+    var.cluster_name,
     "allow-ssh",
     "allow-worker",
     "allow-internal"
   ]
+
+  service_account {
+    email = var.service_account_email
+    scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
 }

--- a/examples/terraform/gcp/modules/worker/variables.tf
+++ b/examples/terraform/gcp/modules/worker/variables.tf
@@ -12,6 +12,8 @@ variable "image_name" {}
 
 variable "ssh_key" {}
 
+variable "service_account_email" {}
+
 variable "worker_count" {
   default = 3
 }

--- a/examples/terraform/gcp/variables.tf
+++ b/examples/terraform/gcp/variables.tf
@@ -20,7 +20,7 @@ variable "gcp_service_credential" {
 
 variable "vpc_mtu" {
   default     = 1500
-  description = "MTU for the VPC. GCP support two MTU values for the VPC: 1440 or 1500"
+  description = "MTU for the VPC. GCP support two MTU values for the VPC: 1460 or 1500"
 }
 
 variable "vpc_cidr" {


### PR DESCRIPTION
* Create a service account and assign the service account to each instance
* Add a tag with same name as instance prefix
* Add `https://www.googleapis.com/auth/cloud-platform` scope to the instance 