### PR TITLE
Update deprecated field in aws provider config, and add MKE version to AWS and Azure

### DIFF
--- a/examples/terraform/aws/main.tf
+++ b/examples/terraform/aws/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region = var.aws_region
-  shared_credentials_file = var.aws_shared_credentials_file
+  shared_credentials_files = [var.aws_shared_credentials_file]
   profile = var.aws_profile
 }
 
@@ -122,6 +122,7 @@ locals {
     kind       = "mke"
     spec = {
       mke = {
+        version       = var.mke_version
         adminUsername = "admin"
         adminPassword = var.admin_password
         installFlags : [
@@ -140,6 +141,7 @@ locals {
     kind       = "mke+msr"
     spec = {
       mke = {
+        version       = var.mke_version
         adminUsername = "admin"
         adminPassword = var.admin_password
         installFlags : [

--- a/examples/terraform/aws/variables.tf
+++ b/examples/terraform/aws/variables.tf
@@ -61,6 +61,11 @@ variable "worker_volume_size" {
 variable "msr_volume_size" {
   default = 100
 }
+
 variable "windows_administrator_password" {
   default = "w!ndozePassw0rd"
+}
+
+variable "mke_version" {
+  default = "3.5.5"
 }

--- a/examples/terraform/azure/main.tf
+++ b/examples/terraform/azure/main.tf
@@ -120,6 +120,7 @@ locals {
     }
     spec = {
       mke = {
+        version       = var.mke_version
         adminUsername = "admin"
         adminPassword = var.admin_password
         installFlags : [

--- a/examples/terraform/azure/variables.tf
+++ b/examples/terraform/azure/variables.tf
@@ -96,3 +96,7 @@ variable "update_domain_count" {
   description = "Specifies the number of update domains that are used"
   default     = 2
 }
+
+variable "mke_version" {
+  default = "3.5.5"
+}

--- a/examples/terraform/gcp/variables.tf
+++ b/examples/terraform/gcp/variables.tf
@@ -84,5 +84,5 @@ variable "windows_password" {
 }
 
 variable "mke_version" {
-  default = "3.5.2"
+  default = "3.5.5"
 }


### PR DESCRIPTION
Changes:
* changed `shared_credentials_file` > `shared_credentials_files`
* Added `mke_version` to `aws` and `azure`, as this is a required field for `launchpad`